### PR TITLE
Feature/iar 5871

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,10 +25,10 @@ steps:
 - task: AndroidSigning@3
   inputs:
     apkFiles: './target-ar-sample/build/outputs/apk/release/target-ar-sample-release-unsigned.apk'
-    apksignerKeystoreFile: 'iar_sample_keystore_23'
-    apksignerKeystorePassword: $(keystorePassword_23)
+    apksignerKeystoreFile: 'iar_keystore'
+    apksignerKeystorePassword: $(keystorePassword)
     apksignerKeystoreAlias: 'iar'
-    apksignerKeyPassword: $(keystorePassword_23)
+    apksignerKeyPassword: $(keystoreAliasPassword)
     zipalign: false
 
 - task: AppCenterDistribute@3

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -75,7 +75,7 @@ dependencies {
     implementation "androidx.navigation:navigation-ui-ktx:$nav_version"
 
     // IAR deps
-    implementation 'com.github.ImagineAR:iar-core-android:1.6.0'
+    implementation 'com.github.ImagineAR:iar-core-android-beta:1.7.1'
 
     implementation 'com.squareup.okhttp3:okhttp:4.9.0'
     implementation 'com.squareup.okhttp3:logging-interceptor:4.9.0'

--- a/core-sample/build.gradle
+++ b/core-sample/build.gradle
@@ -89,8 +89,8 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
 
     // IAR dependencies
-    implementation 'com.github.ImagineAR:iar-core-android:1.6.0'
-    implementation 'com.github.ImagineAR:iar-surface-android:1.6.0'
+    implementation 'com.github.ImagineAR:iar-core-android-beta:1.7.1'
+    implementation 'com.github.ImagineAR:iar-surface-android-beta:1.7.1'
 
     //Preference
     implementation 'androidx.preference:preference:1.1.1'

--- a/surface-ar-sample/build.gradle
+++ b/surface-ar-sample/build.gradle
@@ -77,14 +77,14 @@ dependencies {
     // required to avoid crash on Android 12 API 31
     implementation 'androidx.work:work-runtime-ktx:2.7.1'
 
-    implementation 'com.github.ImagineAR:iar-core-android:1.6.0'
-    implementation 'com.github.ImagineAR:iar-surface-android:1.6.0'
+    implementation 'com.github.ImagineAR:iar-core-android-beta:1.7.1'
+    implementation 'com.github.ImagineAR:iar-surface-android-beta:1.7.1'
 
     /*
     Adding the NFC capability might severely reduce the amount of compatible devices with your application.
     See details: https://docs.imaginear.com/docs/v1.6/android/custom-ar#customize-experiences-using-nfc
     */
-    implementation 'com.github.ImagineAR:iar-nfc-android:1.6.0'
+    implementation 'com.github.ImagineAR:iar-nfc-android-beta:1.7.1'
 
     implementation 'com.squareup.okhttp3:okhttp:4.9.0'
     implementation 'com.squareup.okhttp3:logging-interceptor:4.9.0'

--- a/surface-ar-sample/src/main/java/com/iar/surface_ar_sample/ui/common/BaseViewModel.kt
+++ b/surface-ar-sample/src/main/java/com/iar/surface_ar_sample/ui/common/BaseViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.ViewModel
 import androidx.navigation.NavDirections
 import com.iar.common.NavigationCommand
 import com.iar.common.SingleLiveEvent
+import com.iar.surface_sdk.SurfaceAPI
 
 open class BaseViewModel: ViewModel() {
     // Mutable live data should always be private
@@ -38,5 +39,9 @@ open class BaseViewModel: ViewModel() {
 
     fun navigateRoot() {
         _navigationCommand.postValue(NavigationCommand.ToRoot)
+    }
+
+    fun cancelDownloads(){
+        SurfaceAPI.cancelDownloads()
     }
 }

--- a/surface-ar-sample/src/main/java/com/iar/surface_ar_sample/ui/fragments/location/LocationMarkersFragment.kt
+++ b/surface-ar-sample/src/main/java/com/iar/surface_ar_sample/ui/fragments/location/LocationMarkersFragment.kt
@@ -72,6 +72,11 @@ class LocationMarkersFragment : BaseFragment() {
             }
         }
 
+        binding.downloadOverlay.setOnClickListener {
+            viewModel.cancelDownloads()
+            binding.downloadOverlay.visibility = View.GONE
+        }
+
         return binding.root
     }
 

--- a/surface-ar-sample/src/main/java/com/iar/surface_ar_sample/ui/fragments/nfc/ReadNFCFragment.kt
+++ b/surface-ar-sample/src/main/java/com/iar/surface_ar_sample/ui/fragments/nfc/ReadNFCFragment.kt
@@ -95,6 +95,12 @@ class ReadNFCFragment : BaseFragment() {
                 Utils.showToastMessage("There is error $error", requireContext())
             }
         }
+
+        binding.downloadOverlay.setOnClickListener {
+            nfcViewModel.cancelDownloads()
+            binding.downloadOverlay.visibility = View.GONE
+        }
+
         return binding.root
     }
 

--- a/surface-ar-sample/src/main/java/com/iar/surface_ar_sample/ui/fragments/ondemand/OnDemandMarkersFragment.kt
+++ b/surface-ar-sample/src/main/java/com/iar/surface_ar_sample/ui/fragments/ondemand/OnDemandMarkersFragment.kt
@@ -63,6 +63,12 @@ class OnDemandMarkersFragment : BaseFragment() {
         binding.getMarkerButton.setOnClickListener {
             setupDialog()
         }
+
+        binding.downloadOverlay.setOnClickListener {
+            viewModel.cancelDownloads()
+            binding.downloadOverlay.visibility = View.GONE
+        }
+
         return binding.root
     }
 

--- a/target-ar-sample/build.gradle
+++ b/target-ar-sample/build.gradle
@@ -75,8 +75,8 @@ dependencies {
     implementation "androidx.navigation:navigation-ui-ktx:$nav_version"
 
     // IAR dependencies
-    implementation 'com.github.ImagineAR:iar-core-android:1.6.0'
-    implementation 'com.github.ImagineAR:iar-target-android:1.6.0'
+    implementation 'com.github.ImagineAR:iar-core-android-beta:1.7.1'
+    implementation 'com.github.ImagineAR:iar-target-android-beta:1.7.1'
 
     implementation 'com.squareup.okhttp3:okhttp:4.9.0'
     implementation 'com.squareup.okhttp3:logging-interceptor:4.9.0'


### PR DESCRIPTION
# Overview

Add functionality to cancel download image, on-demand and location marker assets and rewards  when the asset and rewards are downloading.

# Resources

IAR-5871

# Technical Considerations

* For cancelling image markers and rewards, call the function ‘cancelDownloads’ in ‘IARActivity’.
* For cancelling on-demand markers, location markers and rewards, call the function ‘cancelDownloads’ in SurfaceAPI.
# Known Issues

-

# Testing Instructions

* This cancellation is only for cancelling download marker assets and rewards, not cancelling all downloading.
* To test, before click any marker, check the data and cache data in Storage of the app.
* Choose a marker with larger volume, click the downloading indicator to cancel the downloading.
* Check the data and cache data in Storage of the app again, to see if the data changed a lot.
* Finish the downloading, to see if the data and cache data in Storage of the app increase.

# Screenshots

-
